### PR TITLE
Update return format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,7 @@ __pycache__/
 *.log
 *.pdf
 .venv
-src/scanner.egg-info/
-scanner.egg-info/
+src/CheckMarx.egg-info/
 
 !static/img/*
 !forms/questionnaire-filled.png


### PR DESCRIPTION
Support nested checkbox_titles and update return format

This change:
* Updates return format to only give checkbox titles for marxed boxes.
* Allows for multiple columns of checkboxes in a single
questionnaire. (Support for finding these checkboxes remains to be
implemented).

Co-authored-by: Graham Lee <leeg@labrary.online>
